### PR TITLE
[FEAT] 팔로우 Follow 목록 조회 및 상세페이지 기능 구현

### DIFF
--- a/src/main/java/com/Udemy/YeoGiDa/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/follow/controller/FollowController.java
@@ -74,7 +74,7 @@ public class FollowController {
 
     @DeleteMapping("/{toMemberId}")
     public ResponseEntity deleteFollowing(@PathVariable Long toMemberId,
-                                       @LoginMember Member member){
+                                          @LoginMember Member member){
 
         boolean result = followService.unFollow(toMemberId, member.getId());
 
@@ -83,7 +83,7 @@ public class FollowController {
     }
 
 
-    @GetMapping("/{findMemberId}")
+    @GetMapping("/{findMemberId}/detail")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity getPlaceDetail(@PathVariable Long findMemberId) {
         FollowMemberDetailResponseDto result = followService.getFindMemberDetail(findMemberId);

--- a/src/main/java/com/Udemy/YeoGiDa/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/place/repository/PlaceRepositoryImpl.java
@@ -41,7 +41,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom{
 
     @Override
     public List<Place> findAllPlaceByComment(Long memberId) {
-        return queryFactory.selectFrom(place)
+        return queryFactory.selectFrom(place).distinct()
                 .leftJoin(place.comments,comment).fetchJoin()
                 .where(comment.member.id.eq(memberId))
                 .orderBy(comment.id.desc())

--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/controller/TripController.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/controller/TripController.java
@@ -163,6 +163,19 @@ public class TripController {
                 "여행지 목록 조회 성공 - 내가 작성한 ", result), HttpStatus.OK);
     }
 
+    //멤버별 여행지 리스트
+    @GetMapping("/member/{memberId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity getMemberTripList(@PathVariable Long memberId,
+                                            @RequestParam String condition) {
+        List<TripListResponseDto> trips = tripService.getMemberTripList(memberId,condition);
+        Map<String, Object> result = new HashMap<>();
+        result.put("tripList", trips);
+        return new ResponseEntity(DefaultResult.res(StatusCode.OK,
+                "여행지 목록 조회 성공 - 멤버 "+condition, result), HttpStatus.OK);
+    }
+
+
     @ApiOperation("내가 좋아요한 여행지")
     @GetMapping("/my/heart")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepository.java
@@ -19,4 +19,6 @@ public interface TripRepository extends JpaRepository<Trip, Long>, TripRepositor
     List<Trip> findAllSearch(@Param("keyword") String keyword);
 
     List<Trip> findAllByMember(Member member);
+
+    List<Trip> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepositoryCustom.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepositoryCustom.java
@@ -23,8 +23,8 @@ public interface TripRepositoryCustom {
 
     //내가 작성한 여행지 목록
     List<Trip> findAllByMemberFetch(Member m);
-
-    List<Trip> findAllByMemberId(Long memberId);
+    //유저가 작성한 여행지 목록
+    List<Trip> findAllByMemberIdFetch(Long memberId,String condition);
     //친구의 최근 여행지 목록 기본 10개
 //    List<Trip> findAllByFollowingOrderByIdBasicFetch(Member m);
 

--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepositoryImpl.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepositoryImpl.java
@@ -85,7 +85,13 @@ public class TripRepositoryImpl implements TripRepositoryCustom {
     }
 
     @Override
-    public List<Trip> findAllByMemberId(Long memberId) {
-        return null;
+    public List<Trip> findAllByMemberIdFetch(Long memberId,String condition) {
+        return queryFactory.selectFrom(trip)
+                .leftJoin(trip.tripImg, QTripImg.tripImg).fetchJoin()
+                .leftJoin(trip.member, member).fetchJoin()
+                .leftJoin(member.memberImg, QMemberImg.memberImg).fetchJoin()
+                .where(trip.member.id.eq(memberId))
+                .orderBy(conditionParam(condition))
+                .fetch();
     }
 }

--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
@@ -14,6 +14,7 @@ import com.Udemy.YeoGiDa.domain.heart.exception.HeartNotFoundException;
 import com.Udemy.YeoGiDa.domain.heart.repository.HeartRepository;
 import com.Udemy.YeoGiDa.domain.member.entity.Member;
 import com.Udemy.YeoGiDa.domain.member.exception.MemberNotFoundException;
+import com.Udemy.YeoGiDa.domain.member.repository.MemberRepository;
 import com.Udemy.YeoGiDa.domain.trip.entity.Trip;
 import com.Udemy.YeoGiDa.domain.trip.entity.TripImg;
 import com.Udemy.YeoGiDa.domain.trip.exception.HeartTripNotFoundException;
@@ -48,6 +49,7 @@ public class TripService {
     private final HeartRepository heartRepository;
     private final AlarmRepository alarmRepository;
     private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
 
     public List<TripListResponseDto> getTripList(String condition) {
         return tripRepository.findAllByConditionFetch(condition)
@@ -226,6 +228,17 @@ public class TripService {
     //내가 작성한 여행지
     public List<TripListResponseDto> getMyTripList(Member member) {
         return tripRepository.findAllByMemberFetch(member)
+                .stream()
+                .map(TripListResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+   //멤버 여행지
+    public List<TripListResponseDto> getMemberTripList(Long memberId,String condition) {
+
+        memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException());
+
+        return tripRepository.findAllByMemberIdFetch(memberId,condition)
                 .stream()
                 .map(TripListResponseDto::new)
                 .collect(Collectors.toList());


### PR DESCRIPTION
#94

## 💡 관련 이슈
<!--close #이슈넘버-->
close #94 
## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 유저 상세 페이지에서, 유저 정보(좋아요, 팔로워..)와 여행지 리스트 API 분리
