### PR TITLE
[FIX] 팔로잉의 최근 여행지 역순

### DIFF
--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
@@ -415,6 +415,7 @@ public class TripService {
             if (!trip.isEmpty()) {
                 tripBestListResponseDtos.add(new TripBestListResponseDto(trip.get(trip.size() - 1)));
                 if (tripBestListResponseDtos.size() == 10) {
+                    Collections.reverse(tripBestListResponseDtos);
                     return tripBestListResponseDtos;
                 }
             }
@@ -422,6 +423,7 @@ public class TripService {
                 throw new TripNotFoundException();
             }
         }
+        Collections.reverse(tripBestListResponseDtos);
         return tripBestListResponseDtos;
     }
 
@@ -443,6 +445,7 @@ public class TripService {
                 throw new TripNotFoundException();
             }
         }
+        Collections.reverse(tripBestListResponseDtos);
         return tripBestListResponseDtos;
     }
 


### PR DESCRIPTION

## 💡 관련 이슈
close #183

## 🌱 변경 사항 및 이유
- 팔로잉의 최근 여행지 역순으로 정렬해야 최신순이 앞으로 옴

## ❗️ 참고 사항
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->