### PR TITLE
[FEAT] 월간베스트 여행지 초기화시 샘플데이터 넣어놓기

### DIFF
--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
@@ -471,6 +471,7 @@ public class TripService {
     }
 
     //@Scheduler에서 매달 1일마다 하트 변화량을 0으로 수정
+    //추가로 월간 베스트 여행지에 빈 리스트를 보내지 않도록 샘플데이터 3개 추가
     @Transactional
     public void initTripChangeHeartCount() {
         List<Trip> tripList = tripRepository.findAll();
@@ -478,6 +479,14 @@ public class TripService {
             //reset
             trip.initChangeHeartCount();
         }
+
+        //샘플 데이터 3개 하트 추가해놓기
+        Optional<Trip> tripOptional1 = tripRepository.findById(25L);
+        tripOptional1.ifPresent(Trip::plusChangeHeartCount);
+        Optional<Trip> tripOptional2 = tripRepository.findById(32L);
+        tripOptional2.ifPresent(Trip::plusChangeHeartCount);
+        Optional<Trip> tripOptional3 = tripRepository.findById(37L);
+        tripOptional3.ifPresent(Trip::plusChangeHeartCount);
     }
 
     @Transactional


### PR DESCRIPTION

## 💡 관련 이슈
close #185

## 🌱 변경 사항 및 이유
- 월간베스트 여행지가 매월 1일 자정에 초기화되면
  프론트에서 조회할 시 빈리스트가 오게되므로
  3개의 샘플 데이터를 추가하여 사람들이 빈 리스트를 보지않게함

## ❗️ 참고 사항
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->