### PR TITLE
[FIX] 팔로잉의 최근 여행지 empty값 처리

### DIFF
--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepositoryImpl.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/repository/TripRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.Udemy.YeoGiDa.domain.trip.repository;
 
+import com.Udemy.YeoGiDa.domain.follow.exception.NoOneFollowException;
 import com.Udemy.YeoGiDa.domain.follow.repository.FollowRepository;
 import com.Udemy.YeoGiDa.domain.member.entity.Member;
 import com.Udemy.YeoGiDa.domain.member.entity.QMemberImg;
@@ -10,6 +11,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 
@@ -126,6 +128,9 @@ public class TripRepositoryImpl implements TripRepositoryCustom {
     @Override
     public List<Trip> findAllByFollowingOrderByIdBasicFetch(Member m) {
         List<Long> memberIdsByFromMemberId = followRepository.findMemberIdsByFromMemberId(m.getId());
+        if(CollectionUtils.isEmpty(memberIdsByFromMemberId)) {
+            throw new NoOneFollowException();
+        }
 
         return queryFactory.selectFrom(trip)
                 .where(trip.member.id.in(memberIdsByFromMemberId))
@@ -137,6 +142,9 @@ public class TripRepositoryImpl implements TripRepositoryCustom {
     @Override
     public List<Trip> findAllByFollowingOrderByIdMoreFetch(Member m) {
         List<Long> memberIdsByFromMemberId = followRepository.findMemberIdsByFromMemberId(m.getId());
+        if(CollectionUtils.isEmpty(memberIdsByFromMemberId)) {
+            throw new NoOneFollowException();
+        }
 
         return queryFactory.selectFrom(trip)
                 .where(trip.member.id.in(memberIdsByFromMemberId))

--- a/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
+++ b/src/main/java/com/Udemy/YeoGiDa/domain/trip/service/TripService.java
@@ -30,6 +30,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
 import java.util.*;
@@ -403,57 +404,28 @@ public class TripService {
 
     //팔로잉의 최근 여행지 10개
     public List<TripBestListResponseDto> getFollowingsTripListBasic(Member member) {
-//        List<Member> followingMemberList = followRepository.findAllByFromMemberId(member.getId());
-//        if (followingMemberList.isEmpty()) {
-//            throw new NoOneFollowException();
-//        }
-//
-//        List<TripBestListResponseDto> tripBestListResponseDtos = new ArrayList<>();
-//        for (Member followingMember : followingMemberList) {
-//            List<Trip> trip = tripRepository.findAllByMember(followingMember);
-//            if (!trip.isEmpty()) {
-//                tripBestListResponseDtos.add(new TripBestListResponseDto(trip.get(trip.size() - 1)));
-//                if (tripBestListResponseDtos.size() == 10) {
-//                    Collections.reverse(tripBestListResponseDtos);
-//                    return tripBestListResponseDtos;
-//                }
-//            }
-//            if (tripBestListResponseDtos.isEmpty()) {
-//                throw new TripNotFoundException();
-//            }
-//        }
-//        Collections.reverse(tripBestListResponseDtos);
-//        return tripBestListResponseDtos;
-        return tripRepository.findAllByFollowingOrderByIdBasicFetch(member)
+        List<TripBestListResponseDto> collect = tripRepository.findAllByFollowingOrderByIdBasicFetch(member)
                 .stream()
                 .map(TripBestListResponseDto::new)
                 .collect(Collectors.toList());
+
+        if(CollectionUtils.isEmpty(collect)) {
+            throw new TripNotFoundException();
+        }
+        return collect;
     }
 
     //팔로잉의 최근 여행지 모두
     public List<TripBestListResponseDto> getFollwingsTripListMore(Member member) {
-//        List<Member> followingMemberList = followRepository.findAllByFromMemberId(member.getId());
-//        if (followingMemberList.isEmpty()) {
-//            throw new NoOneFollowException();
-//        }
-//
-//        List<TripBestListResponseDto> tripBestListResponseDtos = new ArrayList<>();
-//        for (Member followingMember : followingMemberList) {
-//            List<Trip> trip = tripRepository.findAllByMember(followingMember);
-//            if (!trip.isEmpty()) {
-//                tripBestListResponseDtos.add(new TripBestListResponseDto(trip.get(trip.size() - 1)));
-//            }
-//            //CollectionUtils.isNullOrEmpty
-//            if (tripBestListResponseDtos.isEmpty()) {
-//                throw new TripNotFoundException();
-//            }
-//        }
-//        Collections.reverse(tripBestListResponseDtos);
-//        return tripBestListResponseDtos;
-        return tripRepository.findAllByFollowingOrderByIdMoreFetch(member)
+        List<TripBestListResponseDto> collect = tripRepository.findAllByFollowingOrderByIdMoreFetch(member)
                 .stream()
                 .map(TripBestListResponseDto::new)
                 .collect(Collectors.toList());
+
+        if(CollectionUtils.isEmpty(collect)) {
+            throw new TripNotFoundException();
+        }
+        return collect;
     }
 
     //여행지에 좋아요한 유저들 목록 반환


### PR DESCRIPTION

## 💡 관련 이슈
close #191

## 🌱 변경 사항 및 이유
- 팔로잉의 최근 여행지 empty값 처리
- 중간에 로직을 변경하면서 익셉션 처리가 바뀌었다.
- 팔로잉이 없으면 NoOneFollowingException, 
- 팔로잉 유저가 작성한 글이 없으면 TripNotFoundException을 반환하도록 수정

## ❗️ 참고 사항
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->